### PR TITLE
Update docs for Go 1.6

### DIFF
--- a/dev-setup/devenv.md
+++ b/dev-setup/devenv.md
@@ -11,7 +11,7 @@ This model allows developers to leverage their favorite OS/editors and execute t
 
 ### Prerequisites
 * [Git client](https://git-scm.com/downloads)
-* [Go](https://golang.org/) - 1.5.2 or later
+* [Go](https://golang.org/) - 1.6 or later
 * [Vagrant](https://www.vagrantup.com/) - 1.7.4 or later
 * [VirtualBox](https://www.virtualbox.org/) - 5.0 or later
 * BIOS Enabled Virtualization - Varies based on hardware


### PR DESCRIPTION
For issue https://github.com/openblockchain/obc-dev-env/issues/37. This updates the docs to reflect Go 1.6 usage.

Signed-off-by: <sheehan@us.ibm.com>